### PR TITLE
add production_release and sandbox_release to repo API view

### DIFF
--- a/statusite/repository/models.py
+++ b/statusite/repository/models.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from django.db import models
 from django.urls import reverse
+from django.utils import timezone
 
 from github3 import login
 from django.conf import settings
@@ -47,6 +48,18 @@ class Repository(models.Model):
         release = self.releases.filter(beta=True)[:1]
         if release:
             return release[0]
+
+    @property
+    def production_release(self):
+        for release in self.releases.filter(beta=False):
+            if release.time_push_prod and release.time_push_prod <= timezone.now():
+                return release
+
+    @property
+    def sandbox_release(self):
+        for release in self.releases.filter(beta=False):
+            if release.time_push_sandbox and release.time_push_sandbox <= timezone.now():
+                return release
 
 class Release(models.Model):
     repo = models.ForeignKey(Repository, related_name='releases')

--- a/statusite/repository/serializers.py
+++ b/statusite/repository/serializers.py
@@ -10,6 +10,8 @@ class ReleaseSerializer(serializers.ModelSerializer):
 class RepositorySerializer(serializers.ModelSerializer):
     latest_release = ReleaseSerializer(required=False)
     latest_beta = ReleaseSerializer(required=False)
+    production_release = ReleaseSerializer(required=False)
+    sandbox_release = ReleaseSerializer(required=False)
     class Meta:
         model = Repository
-        fields = ('name', 'owner', 'product_name', 'github_id', 'url', 'latest_release', 'latest_beta')
+        fields = ('name', 'owner', 'product_name', 'github_id', 'url', 'latest_release', 'latest_beta', 'production_release', 'sandbox_release')


### PR DESCRIPTION
Add 2 new release types to the repository API view: production_release and sandbox_release. These are determined by the push dates parsed from the release notes.