### PR TITLE
reload more releases than latest

### DIFF
--- a/statusite/repository/tasks.py
+++ b/statusite/repository/tasks.py
@@ -4,17 +4,21 @@ import django_rq
 from statusite.repository.models import Repository
 
 
+MAX_BETA = 1  # we only need the latest
+MAX_PRODUCTION = 5  # get a few latest in case push dates are canceled
+
 @django_rq.job('default', timeout=60)
 def update_latest_releases():
     db.connection.close()
     n = 0
-    for repo in Repository.objects.all():
-        release = repo.latest_release
-        if release:
+    def reload_releases(releases, beta=False):
+        nonlocal n
+        for k, release in enumerate(releases.filter(beta=beta), start=1):
+            if k > (MAX_BETA if beta else MAX_PRODUCTION):
+                break
             release.reload()
             n += 1
-        release_beta = repo.latest_beta
-        if release_beta:
-            release_beta.reload()
-            n += 1
+    for repo in Repository.objects.all():
+        reload_releases(repo.releases)
+        reload_releases(repo.releases, beta=True)
     return 'Updated {} releases'.format(n)


### PR DESCRIPTION
Now that we will be parsing the push dates from release notes, we should refresh not just the latest production release but several of the most recent. This will be useful in the case that a release older than the most recent is changed to reflect new push dates.