### PR TITLE
remove deprecated URL for repo view

### DIFF
--- a/statusite/repository/urls.py
+++ b/statusite/repository/urls.py
@@ -9,7 +9,6 @@ router = routers.DefaultRouter()
 urlpatterns = [
     #url(r'^', include(router.urls)),
     url(r'webhook/github/release$', repository_views.github_release_webhook, name="github_release_webhook"),
-    url(r'api/(?P<owner>\w+)/(?P<repo>[^/].*)$', repository_views.ApiRepository.as_view(), name="api-repository"),
     url(r'(?P<owner>\w+)/(?P<name>[^/].*)/*$', repository_views.repo_detail, name="repository-detail"),
     url(r'(?P<owner>\w+)/(?P<name>[^/].*)/*$', repository_views.repo_detail, name="release-detail"),
 ]


### PR DESCRIPTION
Remove the URL /repo/api/… because we are instead using /api/repository/…

I was waiting for NimaCloud team to switch over to the new URL and they did so in https://github.com/SalesforceFoundation/Cumulus/pull/2673/commits/a057f8d708f68978ca9a7b048fa860a0894cd018