### PR TITLE
update python version to 3.6.2

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.6.2


### PR DESCRIPTION
Heroku told me to do it:

```bash
remote: -----> Python app detected
remote:  !     The latest version of Python 3 is python-3.6.2 (you are using python-3.5.2, which is unsupported).
remote:  !     We recommend upgrading by specifying the latest version (python-3.6.2).
remote:        Learn More: https://devcenter.heroku.com/articles/python-runtimes
```